### PR TITLE
Reintroduce modload events

### DIFF
--- a/bpt.cpp
+++ b/bpt.cpp
@@ -39,6 +39,14 @@ INT32 usage() {
     return -1;
 }
 
+static void modload(IMG img, VOID *arg)
+{
+    tracer_type *tracer = static_cast<tracer_type *>(arg);
+    const string &name = IMG_Name(img);
+
+    tracer->save().modload(name, IMG_LowAddress(img), IMG_HighAddress(img));
+}
+
 int main(int argc, char *argv[]) {
     PIN_InitSymbols();
     if (PIN_Init(argc, argv)) return usage();
@@ -62,7 +70,8 @@ int main(int argc, char *argv[]) {
                               static_cast<VOID*>(tracer));
     PIN_AddFiniFunction(bpt::tool::fini,
                         static_cast<VOID*>(tracer));
-
+    IMG_AddInstrumentFunction(modload,
+                              static_cast<VOID*>(tracer));
     // Never returns
     PIN_StartProgram();
     

--- a/bpt_frames_saver.hpp
+++ b/bpt_frames_saver.hpp
@@ -23,6 +23,14 @@ struct frames_saver : saver<addr_type, thread> {
     explicit frames_saver(const std::string& path)
         : out(path, arch, machine) {}
 
+    void modload(const std::string& name, addr_type low, addr_type high) {
+        frame f;
+        f.mutable_modload_frame()->set_module_name(name);
+        f.mutable_modload_frame()->set_low_address(low);
+        f.mutable_modload_frame()->set_high_address(high);
+        out.add(f);
+    }
+
     void code_exec(const std::string& dis,
                    addr_type addr,
                    const bytes_type& bytes,

--- a/bpt_saver.hpp
+++ b/bpt_saver.hpp
@@ -7,6 +7,7 @@ typedef std::vector<char> bytes_type;
 
 template <typename addr_type, typename thread>
 struct saver {
+    virtual void modload (const std::string&, addr_type, addr_type) = 0;
     virtual void code_exec(const std::string&,
                            addr_type, const bytes_type&, thread) = 0;
     virtual void memory_load(addr_type, const bytes_type&) = 0;

--- a/bpt_text_saver.hpp
+++ b/bpt_text_saver.hpp
@@ -78,6 +78,14 @@ struct text_saver : saver<addr_type, thread> {
     explicit text_saver(const std::string& path)
         : out(path.c_str(), std::ofstream::out) {}
 
+    void modload(const std::string& name, addr_type low, addr_type high) {
+        out << "modload " << name << ": ";
+        print_addr(out, low);
+        out << " - ";
+        print_addr(out, high);
+        out << std::endl;
+    }
+
     void code_exec(const std::string& dis,
                    addr_type addr,
                    const bytes_type& bytes,


### PR DESCRIPTION
Useful for all kinds of analyses on a captured trace.

Mildly tested; seems to work for my purposes at least.